### PR TITLE
These changes re-enable linting highlighting.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,18 +10,26 @@
 
 """This module exports the Mlint plugin class."""
 
-from SublimeLinter.lint import Linter, const
+import SublimeLinter
+from SublimeLinter.lint import Linter, util
 
+if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
+    from SublimeLinter.lint import const
+    WARNING = const.WARNING
+else:
+    from SublimeLinter.lint import highlight
+    WARNING = highlight.WARNING
 
 class Mlint(Linter):
 
     """Provides an interface to mlint, the standalone MATLAB linter"""
 
     syntax = 'matlab'
-    cmd = 'mlint'
+    cmd = ('mlint', '$file')
     regex = (r'L (?P<line>\d+) \(C (?P<col>\d+)-?(?P<c_end>\d+)?\)'
              r'((?P<error>: Parse error at [^:]*:)|(?P<warning>: ))'
              r'(?P<message>.*)')
     tempfile_suffix = '-'
-    default_type = const.WARNING
+    default_type = WARNING
     comment_re = r'\s*%'
+    error_stream = util.STREAM_STDERR


### PR DESCRIPTION
Update to use WARNING from SL 4 if running in SL 4.

mlint prints warnings on stderr. Set error_stream accordingly.

