### PR TITLE
Resolve SublimeLinter deprecations

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,12 +24,13 @@ class Mlint(Linter):
 
     """Provides an interface to mlint, the standalone MATLAB linter"""
 
-    syntax = 'matlab'
     cmd = ('mlint', '$file')
     regex = (r'L (?P<line>\d+) \(C (?P<col>\d+)-?(?P<c_end>\d+)?\)'
              r'((?P<error>: Parse error at [^:]*:)|(?P<warning>: ))'
              r'(?P<message>.*)')
     tempfile_suffix = '-'
     default_type = WARNING
-    comment_re = r'\s*%'
     error_stream = util.STREAM_STDERR
+    defaults = {
+        'selector': 'source.matlab'
+    }


### PR DESCRIPTION
Resolve breaking changes introduced in SublimeLinter 4.12.0

> mlint: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
> mlint: Defining 'cls.comment_re' has no effect. Please cleanup and remove these settings.
> mlint disabled. 'cls.defaults' is mandatory and MUST be a dict.